### PR TITLE
Change autofocus="true" to autofocus="" per HTML5 spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,12 +265,11 @@ when defining your min/max values in SimpleSchema and it should work correctly.
 You can specify any additional attributes for the helper, and they will be transferred to the resulting DOM element. For example:
 
 ```html
-{{afFieldInput "firstName" autofocus="true" class="inputClass"}}
+{{afFieldInput "firstName" autofocus="" class="inputClass"}}
 ```
 
-For boolean attributes, such as autofocus, you must specify some value after the
-`=`, but the value makes no difference. The mere presence of the attribute will
-cause it to be added to the DOM element.
+For boolean attributes, such as autofocus, you must specify an empty string after the
+`=`.
 
 As mentioned, you must pass in `options` if you want a `<select>` control. The value of the
 options attribute must be an array of objects, where each object has a `label` key and a `value` key. For example:
@@ -745,7 +744,7 @@ framework for the label, use `label-framework`.
 
 ```html
 {{#autoForm schema=docCollection doc=selectedDoc}}
-    {{afQuickField 'firstField' autofocus='true'}}
+    {{afQuickField 'firstField' autofocus=''}}
     {{afQuickField 'weirdColors' style="color: orange" label-style="color: green"}}
     {{afQuickField "longString" rows="5"}}
     {{afQuickField "radioBoolean" radio="true" trueLabel="Yes" falseLabel="No"}}


### PR DESCRIPTION
http://www.w3.org/html/wg/drafts/html/master/infrastructure.html#boolean-attribute

The presence of a boolean attribute on an element represents the true
value, and the absence of the attribute represents the false value.

If the attribute is present, its value must either be the empty string
or a value that is an ASCII case-insensitive match for the attribute's
canonical name, with no leading or trailing whitespace.

I understand this is a little anal since autofocus="true" seems to work just fine. Technically, I believe you can also use autofocus="autofocus" but I decided to keep it simple in the `README`. Of course, feel free to elaborate/reword if you want to.

I only noticed this because I was trying to figure out why it didn't work in Firefox, turns out that while Firefox supports autofocus, it doesn't seem to like when you inject it, boo Firefox, so obviously this change doesn't help that situation any.
