### PR TITLE
feature: Add onSuccess hook when any operation succeeds

### DIFF
--- a/README.md
+++ b/README.md
@@ -463,6 +463,14 @@ myAutoForm.hooks({
     "methodName": function(error, result, template) {}
   },
   onSubmit: function(error, result, template) {},
+
+  //called when any operation succeeds, where operation will be
+  //"insert", "update", "remove", or the method name.
+  onSuccess: function(operation, result, template) {}, 
+
+  //called when any operation fails, where operation will be
+  //"insert", "update", "remove", or the method name.
+  onError: function(operation, error, template) {},
   formToDoc: function(doc) {},
   docToForm: function(doc) {}
 });


### PR DESCRIPTION
I added an onSuccess hook.  My use-case is that I want to display an alert (eg 'Tenant Saved Successfully') when the form submits - whether it's an insert or an update.

Here's how I'm using it to repeat myself a little less:

``` js
var tenantForm;
Meteor.startup(function() {
  tenantForm = new AutoForm(Tenants);
  tenantForm.hooks({
    onSuccess: function(type, result, temlpate) {
      if (type == 'insert') {
        Router.go('tenantDetail', {_id: result})
      }
      Alerts.success('Tenant Saved Succesfully');
    }
  });
});
```

If you think an onError callback would be a good idea too I can add it to the PR.
