### PR TITLE
Add a space to be able to use AutoForm with Meteor UI

### DIFF
--- a/autoform.html
+++ b/autoform.html
@@ -1,5 +1,5 @@
 <template name="_autoForm">
-  <form{{{atts}}}>
+  <form {{{atts}}}>
     {{{content}}}
   </form>
 </template>


### PR DESCRIPTION
Of course there is more work to support the full power of the new Meteor UI. But because the syntax stay almost identical the current package works well on the shark branch... with only one little exception fixed by this commit.

The error was:

```
Error: packages/html-tools/scanner.js:21: Around: "<form(HERE>>>){{{atts}}}": Expected space after tag name (compiling autoform.html)
```
