### PR TITLE
Validation errors and offline form type

### DIFF
--- a/autoform-client.js
+++ b/autoform-client.js
@@ -493,6 +493,16 @@ if (typeof Handlebars !== 'undefined') {
         return result;
       }
 
+      // validation checks
+      if (isInsert && !isValid(insertDoc)) {
+        submitButton.disabled = false;
+        return;
+      }
+      if (method && !isValid(methodDoc)) {
+        submitButton.disabled = false;
+        return;
+      }
+
       //pass both types of doc to onSubmit
       if (hasOnSubmit) {
         if (isValid(insertDoc)) {
@@ -579,22 +589,18 @@ if (typeof Handlebars !== 'undefined') {
       // We won't do an else here so that a method could be called in
       // addition to another action on the same submit
       if (method) {
-        if (isValid(methodDoc)) {
-          Meteor.call(method, methodDoc, function(error, result) {
-            if (error) {
-              onError && onError(method, error, template);
-            } else {
-              if (resetOnSuccess !== false && !template._notInDOM) {
-                template.find("form").reset();
-              }
-              onSuccess && onSuccess(method, result, template);
+        Meteor.call(method, methodDoc, function(error, result) {
+          if (error) {
+            onError && onError(method, error, template);
+          } else {
+            if (resetOnSuccess !== false && !template._notInDOM) {
+              template.find("form").reset();
             }
-            afterMethod && afterMethod(error, result, template);
-            submitButton.disabled = false;
-          });
-        } else {
+            onSuccess && onSuccess(method, result, template);
+          }
+          afterMethod && afterMethod(error, result, template);
           submitButton.disabled = false;
-        }
+        });
       }
 
     },


### PR DESCRIPTION
I've made two changes:
1. Make sure that a failed validation always triggers the `onError` handler. The only chance to act on a failed validation was if the method (insert, update) failed because of an invalid doc. If you wanted to use your own `data-meteor-method` there wouldn't be any error triggered and your method would just be skipped silently.
2. I added a form type called `offline`. I've got a use case where I don't want to trigger any server action at all - no insert, update or custom meteor method and no normal form submit. Just a client-side `onSubmit` handler. This is now possible by adding `class="offline"` to your submit button.
