### PR TITLE
Allow clicking on checkbox labels for bootstrap 3

### DIFF
--- a/templates/bootstrap3/bootstrap3.html
+++ b/templates/bootstrap3/bootstrap3.html
@@ -22,7 +22,7 @@
 </template>
 
 <template name="_afCheckbox_bootstrap3">
-  <div class="checkbox"><label for="{{name}}"><input type="checkbox" data-schema-key="{{name}}" name="{{name}}" value="{{value}}" {{checked}} {{atts}} />{{label}}</label></div>
+  <div class="checkbox"><label><input type="checkbox" data-schema-key="{{name}}" name="{{name}}" value="{{value}}" {{checked}} {{atts}} />{{label}}</label></div>
 </template>
 
 <template name="afCheckbox_bootstrap3">


### PR DESCRIPTION
Clicking on checkbox labels does not work if the for attribute is set on the label.
