### PR TITLE
getFieldValue more robust concerning schema keys

### DIFF
--- a/autoform.js
+++ b/autoform.js
@@ -1256,7 +1256,7 @@ function getFieldsValues(fields) {
 }
 
 function getFieldValue(template, key) {
-  var doc = getFieldsValues(template.findAll('[data-schema-key=' + key + ']'));
+  var doc = getFieldsValues(template.findAll('[data-schema-key="' + key + '"]'));
   return doc && doc[key];
 }
 


### PR DESCRIPTION
A small fix to make the new getFieldValue method more robust with different schema keys (i.e schema keys using dot notation).
