### PR TITLE
Replace {{label}} with {{this.label}}

### DIFF
--- a/templates/bootstrap3-span/bootstrap3-span.html
+++ b/templates/bootstrap3-span/bootstrap3-span.html
@@ -1,3 +1,3 @@
 <template name="afFieldLabel_bootstrap3-span">
-  <span {{atts}}>{{label}}</span>
+  <span {{atts}}>{{this.label}}</span>
 </template>

--- a/templates/bootstrap3/bootstrap3.html
+++ b/templates/bootstrap3/bootstrap3.html
@@ -18,11 +18,11 @@
 </template>
 
 <template name="afFieldLabel_bootstrap3">
-  <label {{atts}}>{{label}}</label>
+  <label {{atts}}>{{this.label}}</label>
 </template>
 
 <template name="_afCheckbox_bootstrap3">
-  <div class="checkbox"><label><input type="checkbox" data-schema-key="{{name}}" name="{{name}}" value="{{value}}" {{checked}} {{atts}} />{{label}}</label></div>
+  <div class="checkbox"><label><input type="checkbox" data-schema-key="{{name}}" name="{{name}}" value="{{value}}" {{checked}} {{atts}} />{{this.label}}</label></div>
 </template>
 
 <template name="afCheckbox_bootstrap3">
@@ -36,7 +36,7 @@
 </template>
 
 <template name="_afRadio_bootstrap3">
-  <div class="radio"><label for="{{name}}"><input type="radio" data-schema-key="{{name}}" name="{{name}}" value="{{value}}" {{checked}} {{atts}} />{{label}}</label></div>
+  <div class="radio"><label for="{{name}}"><input type="radio" data-schema-key="{{name}}" name="{{name}}" value="{{value}}" {{checked}} {{atts}} />{{this.label}}</label></div>
 </template>
 
 <template name="afRadio_bootstrap3">
@@ -65,7 +65,7 @@
     <option value="">{{firstOption}}</option>
     {{/if}}
     {{#each items}}
-      <option value="{{value}}" {{selected}}>{{label}}</option>
+      <option value="{{value}}" {{selected}}>{{this.label}}</option>
     {{/each}}
   </select>
 </template>
@@ -97,7 +97,7 @@
 <template name="afObjectField_bootstrap3">
   <div class="panel panel-default">
     <div class="panel-heading">
-      <h3 class="panel-title">{{label}}</h3>
+      <h3 class="panel-title">{{this.label}}</h3>
     </div>
     <div class="panel-body">
       {{#each fields}}

--- a/templates/plain-span/plain-span.html
+++ b/templates/plain-span/plain-span.html
@@ -1,3 +1,3 @@
 <template name="afFieldLabel_plain-span">
-  <span {{atts}}>{{label}}</span>
+  <span {{atts}}>{{this.label}}</span>
 </template>

--- a/templates/plain/plain.html
+++ b/templates/plain/plain.html
@@ -18,11 +18,11 @@
 </template>
 
 <template name="afFieldLabel_plain">
-  <label {{atts}}>{{label}}</label>
+  <label {{atts}}>{{this.label}}</label>
 </template>
 
 <template name="_afCheckbox_plain">
-  <div><label for="{{name}}"><input type="checkbox" data-schema-key="{{name}}" name="{{name}}" value="{{value}}" {{checked}} {{atts}} />{{label}}</label></div>
+  <div><label for="{{name}}"><input type="checkbox" data-schema-key="{{name}}" name="{{name}}" value="{{value}}" {{checked}} {{atts}} />{{this.label}}</label></div>
 </template>
 
 <template name="afCheckbox_plain">
@@ -36,7 +36,7 @@
 </template>
 
 <template name="_afRadio_plain">
-  <div><label for="{{name}}"><input type="checkbox" data-schema-key="{{name}}" name="{{name}}" value="{{value}}" {{checked}} {{atts}} />{{label}}</label></div>
+  <div><label for="{{name}}"><input type="checkbox" data-schema-key="{{name}}" name="{{name}}" value="{{value}}" {{checked}} {{atts}} />{{this.label}}</label></div>
 </template>
 
 <template name="afRadio_plain">
@@ -65,7 +65,7 @@
     <option value="">{{firstOption}}</option>
     {{/if}}
     {{#each items}}
-    <option value="{{value}}" {{selected}}>{{label}}</option>
+    <option value="{{value}}" {{selected}}>{{this.label}}</option>
     {{/each}}
   </select>
 </template>
@@ -96,7 +96,7 @@
 
 <template name="afObjectField_plain">
   <fieldset>
-    <legend>{{label}}</legend>
+    <legend>{{this.label}}</legend>
     {{#each fields}}
     {{> afQuickField this}}
     {{/each}}


### PR DESCRIPTION
Allows autoform to coexist with UI.registerHelper('label' … as it did before the blaze update. I don't think there is any good reason why you shouldn't do this for atts and autoform's other template context variables as well, but I'm not 100% sure so I left them as is.
