### PR TITLE
Item count when updating model

### DIFF
--- a/autoform.js
+++ b/autoform.js
@@ -1177,7 +1177,7 @@ Template.autoForm.events({
     var data = template.data;
     var formId = data && data.id || defaultFormId;
 
-    var itemCount = $('#'+name+' .list-group .autoform-array-item').size();
+    var itemCount = template.findAll('#'+name+' .list-group .autoform-array-item').size();
 
     setArrayFieldCount(formId, name, itemCount)
     addArrayField(formId, name);


### PR DESCRIPTION
I was using Autoform to make the forms of creating and updating when I found a bug where the count of an array field is 0 even if there are more items inside.

I tried to fix this problem using the count already calculated but not used but if this is not the correct way of doing this I would like to know some indications on how to fix this problem.

Thank you!
