### PR TITLE
taking account of nested properties in omitFields

### DIFF
--- a/autoform.js
+++ b/autoform.js
@@ -627,7 +627,7 @@ Template.afObjectField.innerContext = function (options) {
   fields = _.map(fields, function (field) {
     return name + "." + field;
   });
-  console.log(c.afc.omitFields);
+
   // Get rid of nested fields specified in omitFields
   if(typeof c.afc.omitFields !== "undefined"){
     var omitFields = stringToArray(c.afc.omitFields);


### PR DESCRIPTION
An easy solution to use nested properties in `omitFields` parameter.

format `collection.$.field`
works on unlimited level.

Hope it's not too nasty :)
