### PR TITLE
Access attribute with bracket-notation

### DIFF
--- a/templates/bootstrap3/bootstrap3.js
+++ b/templates/bootstrap3/bootstrap3.js
@@ -12,7 +12,7 @@ Template['afFieldLabel_bootstrap3'].atts = function bsFieldLabelAtts() {
     labelAtts['class'] = "control-label";
   }
   // Add "for" attribute if missing
-  labelAtts.for = labelAtts.for || atts.name;
+  labelAtts['for'] = labelAtts['for'] || atts['name'];
   return labelAtts;
 };
 

--- a/templates/plain/plain.js
+++ b/templates/plain/plain.js
@@ -6,7 +6,7 @@ Template['afFieldLabel_plain'].atts = function plFieldLabelAtts() {
   var atts = (_.clone(this || {})).atts;
   var labelAtts = _.omit(atts, 'name', 'autoform', 'template');
   // Add "for" attribute if missing
-  labelAtts.for = labelAtts.for || atts.name;
+  labelAtts['for'] = labelAtts['for'] || atts['name'];
   return labelAtts;
 };
 


### PR DESCRIPTION
Accessing the attribute "for" with the dot-notation caused an error on IE.  Resolves #171
