### PR TITLE
if the template is not in the DOM, just return

### DIFF
--- a/autoform-events.js
+++ b/autoform-events.js
@@ -35,7 +35,7 @@ function beginSubmit(formId, template) {
 }
 
 function endSubmit(formId, template) {
-  if (!template)
+  if (!template || template._notInDOM)
     return;
   // Get user-defined hooks
   var hooks = Hooks.getHooks(formId, 'endSubmit');


### PR DESCRIPTION
If a reactive variable causes the form to be removed from the DOM as part of a Meteor method changing that variable, an error occurs on line 48

```
var submitButton = template.find("button[type=submit]") || template.find("input[type=submit]");
```

Exception in delivering result of invoking 'addInfoToDeviceAccount': Error: Can't select in removed DomRange
    at DomRange.$ (http://localhost:4000/packages/ui.js?f0696b7e9407b8f11e5838e7e7820e9b6d7fc92f:1403:11)
    at Object.UI.Component.instantiate.inst.templateInstance.findAll (http://localhost:4000/packages/ui.js?f0696b7e9407b8f11e5838e7e7820e9b6d7fc92f:2044:23)
    at Object.UI.Component.instantiate.inst.templateInstance.find (http://localhost:4000/packages/ui.js?f0696b7e9407b8f11e5838e7e7820e9b6d7fc92f:2047:25)
    at endSubmit (http://localhost:4000/packages/autoform.js?c03bd089b3e240aedaea2eaf9bb8b9d7b19a379f:4101:33)
    at autoFormActionCallback (http://localhost:4000/packages/autoform.js?c03bd089b3e240aedaea2eaf9bb8b9d7b19a379f:4200:9)
    at Meteor.bindEnvironment [as _callback](http://localhost:4000/packages/meteor.js?148e9381d225ecad703f4b858769b636ff7a2537:822:22)
    at _.extend._maybeInvokeCallback (http://localhost:4000/packages/livedata.js?502d55e7a7449f770e46330161cb7bd525c4417a:3782:12)
    at _.extend.dataVisible (http://localhost:4000/packages/livedata.js?502d55e7a7449f770e46330161cb7bd525c4417a:3811:10)
    at http://localhost:4000/packages/livedata.js?502d55e7a7449f770e46330161cb7bd525c4417a:4567:7
    at Array.forEach (native) 
