### PR TITLE
Enable textarea to be defined in schema

### DIFF
--- a/autoform.js
+++ b/autoform.js
@@ -845,7 +845,7 @@ function getInputType(atts, defs, expectsArray) {
     type = "email";
   } else if (schemaType === String && defs.regEx === SimpleSchema.RegEx.Url) {
     type = "url";
-  } else if (schemaType === String && atts.rows) {
+  } else if (schemaType === String && (atts.rows || defs.rows) ) {
     type = "textarea";
   } else if (schemaType === Number) {
     type = "number";


### PR DESCRIPTION
This will enable the following example to work:
1. **client/config.js**

``` javascript
SimpleSchema.extendOptions({
  rows: Match.Optional( Number ),
});
```
1. **client/schemas.js**

``` javascript
Schemas = {};
Schemas.myAwesomeSchema = new SimpleSchema({
  notes: {
    type: String,
    label: "Notes",
    rows: 3,
    optional: true,
    max: 1000
  }
});
```
1. **client/views/form.html**

``` javascript
<template name="form">
  {{>quickForm schema=myAwesomeSchema}}
</template>
```

**Result**
A quickForm where 'notes' is rendered as a textarea, without having to use afQuickField
