### PR TITLE
Enable access to child properties by lookup function.

### DIFF
--- a/utility.js
+++ b/utility.js
@@ -129,11 +129,14 @@ Utility = {
    * name on the `window` object. Otherwise returns `obj`.
    */
   lookup: function lookup(obj) {
+    var ref = window, arr;
     if (typeof obj === "string") {
-      if (!window || !window[obj]) {
+      arr = obj.split(".");
+      while(arr.length && (ref = ref[arr.shift()]));
+      if (!ref) {
         throw new Error(obj + " is not in the window scope");
       }
-      return window[obj];
+      return ref;
     }
     return obj;
   },


### PR DESCRIPTION
This will allow to use namespaced (eg. AppCollections.Collection) collections with autoform.  
