### PR TITLE
Fixed date being 12 hours off when passing js Date

### DIFF
--- a/utility.js
+++ b/utility.js
@@ -392,7 +392,7 @@ Utility = {
   dateToNormalizedLocalDateAndTimeString: function dateToNormalizedLocalDateAndTimeString(date, offset) {
     var m = moment(date);
     m.zone(offset);
-    return m.format("YYYY-MM-DD[T]hh:mm:ss.SSS");
+    return m.format("YYYY-MM-DD[T]HH:mm:ss.SSS");
   },
   /**
    * @method  Utility.isValidNormalizedLocalDateAndTimeString


### PR DESCRIPTION
Date is 12 hours off when passing Date to datetime-local in the PM.  Changed text being passed to 24 hour.
