### PR TITLE
Return attributes for afCheckboxGroup_plain

### DIFF
--- a/templates/plain/plain.js
+++ b/templates/plain/plain.js
@@ -24,6 +24,7 @@ Template['quickForm_plain'].submitButtonAtts = function plQuickFormSubmitButtonA
   return atts;
 };
 
+Template["afCheckboxGroup_plain"].atts = 
 Template["afCheckbox_plain"].atts = 
 Template["afRadio_plain"].atts = function () {
   var atts = _.clone(this.atts);


### PR DESCRIPTION
When the plain template is being used for a group of checkboxes, the current values were not being pulled in. This line corrects the issue.
