### PR TITLE
Added an additional condition in bubbleEmpty to ignore date objects.

### DIFF
--- a/utility.js
+++ b/utility.js
@@ -254,7 +254,7 @@ Utility = {
           _.each(val, function (arrayItem) {
             bubbleEmpty(arrayItem);
           });
-        } else if (_.isObject(val)) {
+        } else if (_.isObject(val) && !(val instanceof Date)) {
           var allEmpty = _.all(val, function (prop) {
             return (prop === void 0 || prop === null || (!keepEmptyStrings && typeof prop === "string" && prop.length === 0));
           });


### PR DESCRIPTION
With the current code, Date objects are cleared before validation as outlined in https://github.com/aldeed/meteor-autoform/issues/308. I've added a check to ignore Date objects.
