### PR TITLE
Fixed datetime-local to support DST.

### DIFF
--- a/autoform-inputs.js
+++ b/autoform-inputs.js
@@ -75,9 +75,8 @@ defaultInputValueHandlers = {
 	'input[type=datetime-local]': function () {
 		var val = this.val();
 		val = (typeof val === "string") ? val.replace(/ /g, "T") : val;
-		var offset = this.attr("data-offset") || "Z";
 		if (Utility.isValidNormalizedLocalDateAndTimeString(val)) {
-			return new Date(val + offset);
+			return moment(val).toDate();
 		} else {
 			return null;
 		}

--- a/autoform.js
+++ b/autoform.js
@@ -562,9 +562,7 @@ function getInputValue(name, atts, expectsArray, inputType, value, mDoc, default
         if (inputType === "datetime") {
           return Utility.dateToNormalizedForcedUtcGlobalDateAndTimeString(val);
         } else if (inputType === "datetime-local") {
-          var offset = atts.offset || "Z";
-          // TODO switch to use timezoneId attribute instead of offset
-          return Utility.dateToNormalizedLocalDateAndTimeString(val, offset);
+          return Utility.dateToNormalizedLocalDateAndTimeString(val);
         } else {
           // This fallback will be used for type="date" as well
           // as for select arrays, since it would not make much

--- a/utility.js
+++ b/utility.js
@@ -424,10 +424,8 @@ Utility = {
    *
    * Returns a "valid normalized local date and time string".
    */
-  dateToNormalizedLocalDateAndTimeString: function dateToNormalizedLocalDateAndTimeString(date, offset) {
-    var m = moment(date);
-    m.zone(offset);
-    return m.format("YYYY-MM-DD[T]HH:mm:ss.SSS");
+  dateToNormalizedLocalDateAndTimeString: function dateToNormalizedLocalDateAndTimeString(date) {
+    return moment(date).format("YYYY-MM-DD[T]HH:mm:ss.SSS");
   },
   /**
    * @method  Utility.isValidNormalizedLocalDateAndTimeString


### PR DESCRIPTION
Made changes to fix issues discussed in https://github.com/aldeed/meteor-autoform/issues/344. This removes the need to pass an offset if we're working with local time, but I suspect we should discuss the implications and whether these changes "fix" the issue for me but break the expected behaviour for everyone else. From my understand, `moment()` alone will handle all local time loading and saving without the need to call `zone()` or append a custom offset - both of which can cause issues for DST in the same timezone.
