### PR TITLE
Correction to Custom Insert Form example

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,8 +227,8 @@ Here's an example:
         {{> afFieldInput name='cost'}}
         <span class="input-group-addon">/each</span>
       </div>
-      {{#if afFieldIsInvalid 'cost'}}
-      <span class="help-block">{{afFieldMessage 'cost'}}</span>
+      {{#if afFieldIsInvalid name='cost'}}
+      <span class="help-block">{{afFieldMessage name='cost'}}</span>
       {{/if}}
     </div>
   </fieldset>


### PR DESCRIPTION
Attributes of afFieldIsInvalid and afFieldMessage should be named

This had me foxed for a while..
