### PR TITLE
Fix  #363, run endSubmit even if no after hooks are defined

### DIFF
--- a/autoform-events.js
+++ b/autoform-events.js
@@ -124,6 +124,7 @@ Template.autoForm.events({
             });
           } else if (!afterHooks || !afterHooks.length) {
             // if there are no onError or "after" hooks, throw the error
+            endSubmit(formId, template);
             throw error;
           }
         } else {


### PR DESCRIPTION
Why:
- if I submit, but fail validation the button can stay permanently disabled
  - `beginSubmit` runs and change button to `disabled`, but `endSubmit` is sometimes missing
  - only present if `afterHooks` are missing

Workaround for ppl using older version, add empty `after` hook, e.g.:

```
AutoForm.hooks({
  updateItem: {
    after: {
      update: function () {} // No-op to avoid auto-form bug
    }
  }
})
```

However, ideally we shouldn't need that workaround.
