### PR TITLE
Check to see that domrange isn't removed

### DIFF
--- a/autoform-events.js
+++ b/autoform-events.js
@@ -468,7 +468,7 @@ Template.autoForm.events({
         updateAllTrackedFieldValues(formId);
 
         // Focus the autofocus element
-        if (template && template.view._domrange) {
+        if (template && template.view._domrange && !template.view.isDestroyed) {
           template.$("[autofocus]").focus();
         }
       });


### PR DESCRIPTION
Do this because we defer; domrange might have been removed

Ran into this problem when I redirected to new route before the defered code had a chance to run

https://github.com/meteor/meteor/blob/release/METEOR%401.0/packages/blaze/domrange.js#L408
