### PR TITLE
If value invalid return unmodified value, not null

### DIFF
--- a/inputTypes/datetime-local/datetime-local.js
+++ b/inputTypes/datetime-local/datetime-local.js
@@ -19,7 +19,7 @@ AutoForm.addInputType("datetime-local", {
         return moment(val).toDate();
       }
     } else {
-      return null;
+      return this.val();
     }
   },
   valueConverters: {


### PR DESCRIPTION
When datetime-local input falls back to text, i.e. Firefox, and user
enters an invalid Date string, you’d expect a ‘must be a Date’ error,
instead the value is cleared.
