### PR TITLE
Fix multi-select issue where we were determining selection status based ...

### DIFF
--- a/inputTypes/select-multiple/select-multiple.js
+++ b/inputTypes/select-multiple/select-multiple.js
@@ -17,7 +17,7 @@ AutoForm.addInputType("select-multiple", {
             // #each uses to track unique list items when adding and removing them
             // See https://github.com/meteor/meteor/issues/2174
             _id: subOpt.value,
-            selected: _.contains(context.value, opt.value),
+            selected: _.contains(context.value, subOpt.value),
             atts: context.atts
           };
         });


### PR DESCRIPTION
...on 'opt' value (which is at the group level) instead of the actual option ('subOpt'). Multi-select 'selected' now works.

https://github.com/aldeed/meteor-autoform/issues/501
