### PR TITLE
API for access to internal formData

### DIFF
--- a/autoform-api.js
+++ b/autoform-api.js
@@ -151,6 +151,18 @@ AutoForm.getDefaultTemplateForType = function autoFormGetDefaultTemplateForType(
 };
 
 /**
+ * @method AutoForm.getFormData
+ * @public
+ * @param {String} formId The `id` attribute of the `autoForm` you want data for.
+ * @return {Object}
+ *
+ * Returns an object containing all of the data for the specified form.
+ */
+AutoForm.getFormData = function autoFormGetFormData(formId) {
+  return formData[formId];
+};
+
+/**
  * @method AutoForm.getFormValues
  * @public
  * @param {String} formId The `id` attribute of the `autoForm` you want current values for.


### PR DESCRIPTION
I needed this to get a form’s SimpleSchema. Specifically, I needed to specify the SS for a call to RemoveFromFieldAtIndex as it requires it. But I think this will be useful in other scenarios as well.