### PR TITLE
fixed button align in bootstrap3-inline by increasing the specificity of...

### DIFF
--- a/templates/bootstrap3-inline/bootstrap3-inline.css
+++ b/templates/bootstrap3-inline/bootstrap3-inline.css
@@ -1,3 +1,3 @@
-.autoform-inline-align {
+.btn.autoform-inline-align {
   vertical-align: top;
 }


### PR DESCRIPTION
When using the bootstrap3-inline template the button was aligned to middle and not to the top. Increased the specificity of the autoform-align-inline selector to override the vertical-align: top, which comes from bootstrap's .btn class.

![image](https://cloud.githubusercontent.com/assets/2065955/6234554/f3d7d022-b6db-11e4-9c8e-cee50a4ea16f.png)

(PR off devel, instead of master)
