### PR TITLE
IE8 compatibility

### DIFF
--- a/components/afFormGroup/afFormGroup.js
+++ b/components/afFormGroup/afFormGroup.js
@@ -5,7 +5,7 @@ Template.afFormGroup.helpers({
     var afFieldInputAtts = formGroupInputAtts(c.atts);
     var id = c.atts["id-prefix"] || "";
     id += c.atts.id || c.atts.name.replace(".", "-");
-    afFieldLabelAtts.for = afFieldInputAtts.id = id;
+    afFieldLabelAtts["for"] = afFieldInputAtts.id = id;
     return {
       skipLabel: (c.atts.label === false),
       afFieldLabelAtts: afFieldLabelAtts,


### PR DESCRIPTION
Unfortunately, IE8 still accounts for a couple percent of Internet users. Using the dot notation to access the `for` attribute of an object causes an exception in that browser, and there's an easy way to avoid this.

By the way, thanks for this great package!