### PR TITLE
Fixed AutoForm.Utility.dateToDateString* methods

### DIFF
--- a/package.js
+++ b/package.js
@@ -224,5 +224,6 @@ Package.onUse(function(api) {
 
 Package.onTest(function (api) {
   api.use(['aldeed:autoform', 'tinytest', 'underscore']);
+  api.use('momentjs:moment', 'client');
   api.addFiles(['tests/utility-tests.js', 'tests/autoform-tests.js']);
 });

--- a/tests/utility-tests.js
+++ b/tests/utility-tests.js
@@ -290,6 +290,26 @@ if (Meteor.isClient) {
     });
   });
 
+  var startOfDayUTC = moment.utc("0001-3-14", "YYYY-MM-DD").toDate();
+  var endOfDayUTC = moment.utc("0001-3-14 23:59:59", "YYYY-MM-DD HH:mm:ss").toDate();
+  Tinytest.add('AutoForm - Utility - dateToDateString', function(test) {
+    // There's no way to set the timezone for Javascript's Date object, so
+    // we check what the current timezone is.
+    var tzOffset = new Date().getTimezoneOffset();
+    if(tzOffset > 0) {
+      test.equal(AutoForm.Utility.dateToDateString(startOfDayUTC), "0001-03-13");
+    } else if(tzOffset < 0) {
+      test.equal(AutoForm.Utility.dateToDateString(endOfDayUTC), "0001-03-15");
+    } else {
+      test.equal(AutoForm.Utility.dateToDateString(startOfDayUTC), "0001-03-14");
+      test.equal(AutoForm.Utility.dateToDateString(endOfDayUTC), "0001-03-14");
+    }
+  });
+  Tinytest.add('AutoForm - Utility - dateToDateStringUTC', function(test) {
+    test.equal(AutoForm.Utility.dateToDateStringUTC(startOfDayUTC), "0001-03-14");
+    test.equal(AutoForm.Utility.dateToDateStringUTC(endOfDayUTC), "0001-03-14");
+  });
+
 }
 
 //Test API:

--- a/utility.js
+++ b/utility.js
@@ -335,15 +335,7 @@ Utility = {
    * Returns a "valid date string" representing the local date.
    */
   dateToDateString: function dateToDateString(date) {
-    var m = (date.getMonth() + 1);
-    if (m < 10) {
-      m = "0" + m;
-    }
-    var d = date.getDate();
-    if (d < 10) {
-      d = "0" + d;
-    }
-    return date.getFullYear() + '-' + m + '-' + d;
+    return moment(date).format("YYYY-MM-DD");
   },
   /**
    * @method  Utility.dateToDateStringUTC
@@ -354,15 +346,7 @@ Utility = {
    * Returns a "valid date string" representing the date converted to the UTC time zone.
    */
   dateToDateStringUTC: function dateToDateStringUTC(date) {
-    var m = (date.getUTCMonth() + 1);
-    if (m < 10) {
-      m = "0" + m;
-    }
-    var d = date.getUTCDate();
-    if (d < 10) {
-      d = "0" + d;
-    }
-    return date.getUTCFullYear() + '-' + m + '-' + d;
+    return moment.utc(date).format("YYYY-MM-DD");
   },
   /**
    * @method  Utility.dateToNormalizedForcedUtcGlobalDateAndTimeString


### PR DESCRIPTION
AutoForm.Utility.dateToDateStringUTC and AutoForm.Utility.dateToDateString now correctly handle dates with years < 1000. This fixes #774.

I added a TinyTest for this, which was a little tricky because we cannot
control the timezone the tests run in (the behavior of AutoForm.Utility.dateToDateString
is influenced by the timezone). I opted to have the test check what
timezone we're in, and assert appropriately (the 3 interesting cases
are: we're ahead of UTC, we're behind UTC, and we're in UTC). To test
these, I ran firefox with the TZ environment variable set:

```bash
TZ=UTC firefox
>> new Date().getTimezoneOffset()
0

TZ=Europe/Amsterdam firefox
>> new Date().getTimezoneOffset()
-60

TZ=America/Los_Angeles firefox
>> new Date().getTimezoneOffset()
420
```

The tests passed under all 3 instances of firefox.