### PR TITLE
Add return to afOptionsFromSchema helper

### DIFF
--- a/autoform-helpers.js
+++ b/autoform-helpers.js
@@ -272,7 +272,7 @@ Template.registerHelper('afSelectOptionAtts', function afSelectOptionAtts() {
 
 // Expects to be called with this.name available
 Template.registerHelper('afOptionsFromSchema', function afOptionsFromSchema() {
-  AutoForm._getOptionsForField(this.name);
+  return AutoForm._getOptionsForField(this.name);
 });
 
 /*


### PR DESCRIPTION
Hey aldeed,

I noticed that my select options were not showing up using the new ```{{> afQuickField name=this.name options=afOptionsFromSchema}}``` format. 

I managed to trace it down to this helper:
```
Template.registerHelper('afOptionsFromSchema', function afOptionsFromSchema() {
  AutoForm._getOptionsForField(this.name);
});
```

I believe it should be:
```
Template.registerHelper('afOptionsFromSchema', function afOptionsFromSchema() {
  return AutoForm._getOptionsForField(this.name);
});
```

Otherwise the results of _getOptionsForField are not being returned to the template.