### PR TITLE
Add try/catch to _validateField method

### DIFF
--- a/autoform-validation.js
+++ b/autoform-validation.js
@@ -30,7 +30,10 @@ function _validateField(key, formId, skipEmpty, onlyIfAlreadyInvalid) {
 
   // Due to throttling, this can be called after the autoForm template is destroyed.
   // If that happens, we exit without error.
-  var template = AutoForm.templateInstanceForForm(formId);
+  var template;
+  try{
+    template = AutoForm.templateInstanceForForm(formId);
+  }catch(e){}
   if (!template || !template.view._domrange || template.view.isDestroyed) {
     return;
   }


### PR DESCRIPTION
Hey again aldeed,

I was receiving the error "No form with ID stepViewForm is currently rendered. If this call originated from within a template event or helper, you should call without passing a formId to avoid seeing this error" after navigating to a new template where the form is not present.

I am calling Router.go from within an onSubmit AutoForm hook:
```
onSubmit: function(insertDoc) {
      this.event.preventDefault();
      this.done();
      Router.go(...);
}
```

It appears that ```this.done()``` does not stop the throttled field validation, as after I navigate to the next route, the error fires (not always though).

From the comment "Due to throttling, this can be called after the autoForm template is destroyed. If that happens, we exit without error." I take it you want this method to be able to fail silently. I doubt you want to remove the error in ```viewForForm```, so I added a try/catch around the ```templateInstanceForForm``` method call.

I don't know if this would be your preferred method but it got me working again. Might want to address it properly without the need for a try/catch.