### PR TITLE
Fix validation for autoForm's with no type set

### DIFF
--- a/formTypes/normal.js
+++ b/formTypes/normal.js
@@ -59,6 +59,6 @@ AutoForm.addFormType('normal', {
     // Get SimpleSchema
     var ss = AutoForm.getFormSchema(this.form.id);
     // Validate
-    return AutoForm._validateFormDoc(this.formDoc, false, this.form.id, ss, this.form);
+    return AutoForm._validateFormDoc(this.formDoc.insertDoc, false, this.form.id, ss, this.form);
   }
 });


### PR DESCRIPTION
Hey @aldeed, as per issue #829, forms without a type are no longer working. I was getting validation errors in console due to:

```
return AutoForm._validateFormDoc(this.formDoc, false, this.form.id, ss, this.form);
```

where formDoc contains both ```insertDoc``` and ```updateDoc```

I believe changing this to:

```
return AutoForm._validateFormDoc(this.formDoc.insertDoc, false, this.form.id, ss, this.form);
```

will fix the issue. I can't imagine forms without a type wanting to use the updateDoc for validation anyway.