### PR TITLE
Fix for checkboxes and radio buttons not triggering form change event

### DIFF
--- a/autoform-events.js
+++ b/autoform-events.js
@@ -381,7 +381,16 @@ Template.autoForm.events({
     // loops by continually saying the field changed when it did not,
     // especially in an autosave situation. This is an attempt to
     // prevent that from happening.
-    var keyVal = key + '___' + event.target.value;
+    var keyVal;
+    switch(event.target.type){
+      case 'checkbox':
+      case 'radio':
+        keyVal = $(event.target).prop('checked');
+        break;
+      default:
+        keyVal = key + '___' + event.target.value;
+    }
+
     if (keyVal === lastKeyVal) {
       return;
     }


### PR DESCRIPTION
Hey Aldeed,

This is a fix for #861. Checkboxes and radio buttons do not pass the infinite loop protection you have in place on the ```change form``` event handler. This adds compatibility for checkbox and radio buttons, and provides a framework for other input types if necessary in the future.

Cheers!