### PR TITLE
Options for afFormGroup and afObjectField

### DIFF
--- a/README.md
+++ b/README.md
@@ -493,8 +493,12 @@ group, that is, everything related to a single field -- the label, the input,
 and the error message -- in one line.
 
 This component accepts the same attributes as `afFieldInput`.
-Attributes that are prefixed with `label-` become attributes on the rendered `label` element while
-any remaining attributes are forwarded to the `afFieldInput` component. You can also set `label=false` to omit the `label` element or set `label` to a string to use that text as the label text.
+Attributes that are prefixed with `formgroup-` become attributes on the `div` 
+element, which contains the label and the field. Attributes that are prefixed 
+with `label-` become attributes on the rendered `label` element while any 
+remaining attributes are forwarded to the `afFieldInput` component. You can 
+also set `label=false` to omit the `label` element or set `label` to a 
+string to use that text as the label text.
 
 ### afQuickField
 

--- a/components/afFormGroup/afFormGroup.js
+++ b/components/afFormGroup/afFormGroup.js
@@ -6,6 +6,7 @@ Template.afFormGroup.helpers({
   },
   innerContext: function afFormGroupContext() {
     var c = AutoForm.Utility.getComponentContext(this, 'afFormGroup');
+    var afFormGroupAtts = formGroupAtts(c.atts);
     var afFieldLabelAtts = formGroupLabelAtts(c.atts);
     var afFieldInputAtts = formGroupInputAtts(c.atts);
 
@@ -30,6 +31,8 @@ Template.afFormGroup.helpers({
 
     return {
       skipLabel: (c.atts.label === false),
+      afFormGroupClass: c.atts['formgroup-class'],
+      afFormGroupAtts: afFormGroupAtts,
       afFieldLabelAtts: afFieldLabelAtts,
       afFieldInputAtts: afFieldInputAtts,
       name: c.atts.name,
@@ -43,6 +46,17 @@ Template.afFormGroup.helpers({
  * Private
  */
 
+function formGroupAtts(atts) {
+  // Separate formgroup options from input options; formgroup items begin with 'formgroup-'
+  var labelAtts = {};
+  _.each(atts, function autoFormLabelAttsEach(val, key) {
+    if (key.indexOf('formgroup-') === 0 && key != 'formgroup-class') {
+      labelAtts[key.substring(10)] = val;
+    }
+  });
+  return labelAtts;
+}
+
 function formGroupLabelAtts(atts) {
   // Separate label options from input options; label items begin with 'label-'
   var labelAtts = {};
@@ -55,11 +69,11 @@ function formGroupLabelAtts(atts) {
 }
 
 function formGroupInputAtts(atts) {
-  // Separate label options from input options; label items begin with 'label-'
+  // Separate input options from label and formgroup options
   // We also don't want the 'label' option
   var inputAtts = {};
   _.each(atts, function autoFormLabelAttsEach(val, key) {
-    if (['id-prefix', 'id', 'label'].indexOf(key) === -1 && key.indexOf('label-') !== 0) {
+    if (['id-prefix', 'id', 'label'].indexOf(key) === -1 && key.indexOf('label-') !== 0 && key.indexOf('formgroup-') !== 0) {
       inputAtts[key] = val;
     }
   });

--- a/components/afObjectField/afObjectField.html
+++ b/components/afObjectField/afObjectField.html
@@ -1,3 +1,3 @@
 <template name="afObjectField">
-  {{> Template.dynamic template=getTemplateName data=this}}
+  {{> Template.dynamic template=getTemplateName data=innerContext}}
 </template>

--- a/components/afObjectField/afObjectField.js
+++ b/components/afObjectField/afObjectField.js
@@ -6,7 +6,6 @@ Template.afObjectField.helpers({
   },
   innerContext: function() {
     var c = AutoForm.Utility.getComponentContext(this, 'afObjectField');
-    _.extend(this, c.atts);
-    return this;
+    return _.extend({{}, this, c.atts);
   }
 });

--- a/components/afObjectField/afObjectField.js
+++ b/components/afObjectField/afObjectField.js
@@ -6,6 +6,6 @@ Template.afObjectField.helpers({
   },
   innerContext: function() {
     var c = AutoForm.Utility.getComponentContext(this, 'afObjectField');
-    return _.extend({{}, this, c.atts);
+    return _.extend({}, this, c.atts);
   }
 });

--- a/components/afObjectField/afObjectField.js
+++ b/components/afObjectField/afObjectField.js
@@ -3,5 +3,10 @@
 Template.afObjectField.helpers({
   getTemplateName: function () {
     return AutoForm.getTemplateName('afObjectField', this.template, this.name);
+  },
+  innerContext: function() {
+    var c = AutoForm.Utility.getComponentContext(this, 'afObjectField');
+    _.extend(this, c.atts);
+    return this;
   }
 });

--- a/templates/bootstrap3-horizontal/components/afFormGroup/afFormGroup.html
+++ b/templates/bootstrap3-horizontal/components/afFormGroup/afFormGroup.html
@@ -1,5 +1,5 @@
 <template name="afFormGroup_bootstrap3-horizontal">
-  <div class="form-group {{#if afFieldIsInvalid name=this.name}}has-error{{/if}}" data-required={{required}}>
+  <div class="form-group {{#if afFieldIsInvalid name=this.name}}has-error{{/if}} {{afFormGroupClass}}" data-required={{required}} {{afFormGroupAtts}}>
     {{#if skipLabel}}
     {{! We include the empty label as the easiest way to keep proper field alignment}}
     <label {{afFieldLabelAtts}}></label>

--- a/templates/bootstrap3-horizontal/components/afObjectField/afObjectField.html
+++ b/templates/bootstrap3-horizontal/components/afObjectField/afObjectField.html
@@ -2,8 +2,8 @@
   <div class="form-group {{#if afFieldIsInvalid name=this.name}}has-error{{/if}}">
     <label {{afFieldLabelAtts}}>{{afFieldLabelText name=this.name}}</label>
     <div class="{{rightColumnClass}}">
-      <div class="panel panel-default autoform-padding-fix">
-        <div class="panel-body">
+      <div class="panel panel-default autoform-padding-fix {{panelClass}}">
+        <div class="panel-body {{bodyClass}}">
           {{> afQuickFields quickFieldsAtts}}
         </div>
       </div>

--- a/templates/bootstrap3-inline/bootstrap3-inline.html
+++ b/templates/bootstrap3-inline/bootstrap3-inline.html
@@ -14,7 +14,7 @@
 </template>
 
 <template name="afFormGroup_bootstrap3-inline">
-  <div class="form-group {{#if afFieldIsInvalid name=this.name}}has-error{{/if}}" data-required={{required}}>
+  <div class="form-group {{#if afFieldIsInvalid name=this.name}}has-error{{/if}} {{afFormGroupClass}}" data-required={{required}} {{afFormGroupAtts}}>
     {{#unless skipLabel}}
     <label {{afFieldLabelAtts}}>{{#if this.labelText}}{{this.labelText}}{{else}}{{afFieldLabelText name=this.name}}{{/if}}</label>
     {{/unless}}

--- a/templates/bootstrap3/components/afFormGroup/afFormGroup.html
+++ b/templates/bootstrap3/components/afFormGroup/afFormGroup.html
@@ -1,5 +1,5 @@
 <template name="afFormGroup_bootstrap3">
-  <div class="form-group {{#if afFieldIsInvalid name=this.name}}has-error{{/if}}" data-required={{required}}>
+  <div class="form-group {{#if afFieldIsInvalid name=this.name}}has-error{{/if}} {{afFormGroupClass}}" data-required={{required}} {{afFormGroupAtts}}>
     {{#unless skipLabel}}
     <label {{bsFieldLabelAtts}}>{{#if this.labelText}}{{this.labelText}}{{else}}{{afFieldLabelText name=this.name}}{{/if}}</label>
     {{/unless}}

--- a/templates/bootstrap3/components/afObjectField/afObjectField.html
+++ b/templates/bootstrap3/components/afObjectField/afObjectField.html
@@ -1,11 +1,11 @@
 <template name="afObjectField_bootstrap3">
-  <div class="panel panel-default">
+  <div class="panel {{panelClass}}">
     {{#with afFieldLabelText name=this.name}}
-    <div class="panel-heading">
+    <div class="panel-heading {{headingClass}}">
       <h3 class="panel-title">{{this}}</h3>
     </div>
     {{/with}}
-    <div class="panel-body">
+    <div class="panel-body {{bodyClass}}">
       {{#if afFieldIsInvalid name=this.name}}
       <span class="help-block">{{{afFieldMessage name=this.name}}}</span>
       {{/if}}

--- a/templates/bootstrap3/components/afObjectField/afObjectField.js
+++ b/templates/bootstrap3/components/afObjectField/afObjectField.js
@@ -1,5 +1,8 @@
 Template.afObjectField_bootstrap3.helpers({
   quickFieldsAtts: function () {
     return _.pick(this, 'name', 'id-prefix');
+  },
+  panelClass: function() {
+    return this.panelClass || 'panel-default';
   }
 });

--- a/templates/plain/components/afFormGroup/afFormGroup.html
+++ b/templates/plain/components/afFormGroup/afFormGroup.html
@@ -1,5 +1,5 @@
 <template name="afFormGroup_plain">
-  <div class="{{#if afFieldIsInvalid name=this.name}}has-error{{/if}}" data-required={{required}}>
+  <div class="{{#if afFieldIsInvalid name=this.name}}has-error{{/if}} {{afFormGroupClass}}" data-required={{required}} {{afFormGroupAtts}}>
     {{#unless this.skipLabel}}
     <label {{this.afFieldLabelAtts}}>{{#if this.labelText}}{{this.labelText}}{{else}}{{afFieldLabelText name=this.name}}{{/if}}</label>
     {{/unless}}


### PR DESCRIPTION
I extended the autoform attributes for “nicer” forms using the Bootstrap grid, e. g. to display first name and surname or ZIP and city side by side.

Example:

```javascript
Schema.Registration = new SimpleSchema({
	'participant': {
		type: Object,
		autoform: { 
			afObjectField: {
				bodyClass: 'container-fluid row'
			}
		}
	},
	'participant.firstname': {
		type: String,
		autoform: { 
			afFormGroup: {
				'formgroup-class': 'col-sm-6'
			},
		}
	},
	'participant.lastname': {
		type: String,
		autoform: { 
			afFormGroup: {
				'formgroup-class': 'col-sm-6'
			},
		}
	},
	…
};
```

![github firstname lastname](https://cloud.githubusercontent.com/assets/8255864/7612434/2595e85a-f98b-11e4-8fac-3108d4fceaae.png)
