### PR TITLE
Allow user to specify a DDP Connection to use when calling Meteor methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,6 +363,8 @@ set (the same effect as setting a `value` attribute on each field within the for
 * `type`: Optional. The form type. Default if not provided is "normal". See [Form Types](#form-types).
 * `meteormethod`: Optional. When `type` is "method", indicate the name of the
 Meteor method in this attribute.
+* `ddp`: Optional. When `type` is "method", provide a DDP Connection that should
+be used to call the Meteor method in this attribute.
 * `resetOnSuccess`: Optional. The form is automatically reset
 for you after a successful submission action. You can skip this by setting this
 attribute to `false`.
@@ -641,6 +643,8 @@ Use the `scope` attribute on your form to define the array field into which the 
 
 Will call the server method with the name you specify in the `meteormethod` attribute. Passes a single argument, `doc`, which is the document resulting from the form submission.
 
+You may optionally specify a DDP Connection in the 'ddp' attribute. If you do, the method will be called using the ddp connection provided.
+
 The method is not called until `doc` is valid on the client.
 
 **You must call `check()` in the method or perform your own validation since a user could bypass the client side validation.**
@@ -651,6 +655,8 @@ Will call the server method with the name you specify in the `meteormethod` attr
 
 * `modifier`: the modifier object generated from the form values
 * `documentId`: the `_id` of the document being updated
+
+You may optionally specify a DDP Connection in the 'ddp' attribute. If you do, the method will be called using the ddp connection provided.
 
 The method is not called until `modifier` is valid on the client.
 
@@ -980,7 +986,7 @@ var hooksObject = {
     // alter doc
     // return doc;
   },
-  
+
   // Called every time an update or typeless form
   // is revalidated, which can be often if keyup
   // validation is used.

--- a/autoform-api.js
+++ b/autoform-api.js
@@ -465,9 +465,9 @@ AutoForm.getInputTypeTemplateNameForElement = function autoFormGetInputTypeTempl
 AutoForm.getInputValue = function autoFormGetInputValue(element, ss) {
   var field, fieldName, fieldType, arrayItemFieldType, val, typeDef, inputTypeTemplate, dataContext, autoConvert;
 
-  Tracker.nonreactive(function() { 
+  Tracker.nonreactive(function() {
     //don't rerun when data context of element changes, can cause infinite loops
-    
+
     dataContext = Blaze.getData(element);
     if (dataContext && dataContext.atts) {
       autoConvert = dataContext.atts.autoConvert;

--- a/formTypes/method-update.js
+++ b/formTypes/method-update.js
@@ -27,7 +27,14 @@ AutoForm.addFormType('method-update', {
         c.failedValidation();
       } else {
         // Call the method
-        Meteor.call(c.formAttributes.meteormethod, updateDoc, c.docId, c.result);
+        // if a ddp connection was provided, use that instead of the default
+        // Meteor connection
+        var ddp = c.formAttributes.ddp;
+        if (ddp && ddp.call && typeof ddp.call === 'function') {
+          ddp.call(c.formAttributes.meteormethod, updateDoc, c.docId, c.result);
+        } else {
+          Meteor.call(c.formAttributes.meteormethod, updateDoc, c.docId, c.result);
+        }
       }
     });
   },

--- a/formTypes/method.js
+++ b/formTypes/method.js
@@ -27,7 +27,15 @@ AutoForm.addFormType('method', {
         c.failedValidation();
       } else {
         // Call the method
-        Meteor.call(c.formAttributes.meteormethod, doc, c.result);
+        // if a ddp connection was provided, use that instead of the default
+        // Meteor connection
+        var ddp = c.formAttributes.ddp;
+        if (ddp && ddp.call && typeof ddp.call === 'function') {
+          ddp.call(c.formAttributes.meteormethod, doc, c.result);
+        } else {
+          Meteor.call(c.formAttributes.meteormethod, doc, c.result);
+        }
+
       }
     });
   },

--- a/package.js
+++ b/package.js
@@ -2,7 +2,7 @@ Package.describe({
   name: "aldeed:autoform",
   summary: "Easily create forms with automatic insert and update, and automatic reactive validation.",
   git: "https://github.com/aldeed/meteor-autoform.git",
-  version: "5.1.2"
+  version: "5.1.3"
 });
 
 Package.onUse(function(api) {


### PR DESCRIPTION
```html
{{#autoForm schema=myForm id="myForm" type="method" meteormethod="doStuff" ddp=DDPConnection}}
  <!-- ... -->
{{/autoForm}}
```

Just pass in DDPConnection from a template helper

```javascript
Template.myForm.helpers({
    DDPConnection: function() {
        return DDP.connect(url); 
        // return Cluster.discoverConnection('service'); // also works with meteor-cluster!
    }
});
```