### PR TITLE
Remove 'autosave' value from 'removeProps'

### DIFF
--- a/components/autoForm/autoForm.js
+++ b/components/autoForm/autoForm.js
@@ -13,7 +13,6 @@ Template.autoForm.helpers({
       "resetOnSuccess",
       "type",
       "template",
-      "autosave",
       "autosaveOnKeyup",
       "meteormethod",
       "filter",


### PR DESCRIPTION
I working on "universe-select" package and I need "autosave" value in contextAdjust in "addInputType".
Could You leave "autosave" value in context?