### PR TITLE
Reactive schema

### DIFF
--- a/autoform-api.js
+++ b/autoform-api.js
@@ -477,9 +477,9 @@ AutoForm.getInputTypeTemplateNameForElement = function autoFormGetInputTypeTempl
 AutoForm.getInputValue = function autoFormGetInputValue(element, ss) {
   var field, fieldName, fieldType, arrayItemFieldType, val, typeDef, inputTypeTemplate, dataContext, autoConvert;
 
-  Tracker.nonreactive(function() { 
+  Tracker.nonreactive(function() {
     //don't rerun when data context of element changes, can cause infinite loops
-    
+
     dataContext = Blaze.getData(element);
     if (dataContext && dataContext.atts) {
       autoConvert = dataContext.atts.autoConvert;
@@ -875,8 +875,11 @@ AutoForm.getInputType = function getInputType(atts) {
  * Call this method from a UI helper to get the field definitions based on the schema used by the closest containing autoForm.
  */
 AutoForm.getSchemaForField = function autoFormGetSchemaForField(name) {
-  var ss = AutoForm.getFormSchema();
-  return AutoForm.Utility.getDefs(ss, name);
+  var ss = AutoForm.getFormSchema(), defs = {};
+  try{
+    defs = AutoForm.Utility.getDefs(ss, name);
+  }catch(e){}
+  return defs;
 };
 
 /**

--- a/autoform-helpers.js
+++ b/autoform-helpers.js
@@ -5,9 +5,9 @@ function parseOptions(options) {
   // Find the form's schema
   var ss = AutoForm.getFormSchema();
   // Call getDefs for side effect of throwing errors when name is not in schema
-  if (hash.name) {
-    AutoForm.Utility.getDefs(ss, hash.name);
-  }
+  //if (hash.name) {
+  //  AutoForm.Utility.getDefs(ss, hash.name);
+  //}
   return _.extend({}, hash, {ss: ss});
 }
 

--- a/autoform-inputs.js
+++ b/autoform-inputs.js
@@ -166,7 +166,8 @@ function markChanged(template, fieldName) {
     if (template &&
         template.view &&
         template.view._domrange &&
-        !template.view.isDestroyed) {
+        !template.view.isDestroyed &&
+        template.formValues[fieldName]) {
 
       template.formValues[fieldName].changed();
       template.formValues[fieldName].requestInProgress = false;

--- a/utility.js
+++ b/utility.js
@@ -118,6 +118,9 @@ Utility = {
    */
   getSelectOptions: function getSelectOptions(defs, hash) {
     var schemaType = defs.type;
+    if(!schemaType){
+      return;
+    }
     var selectOptions = hash.options;
 
     // Handle options="allowed"
@@ -435,11 +438,15 @@ Utility = {
    * an error if we can't find an autoform context.
    */
   getComponentContext: function autoFormGetComponentContext(context, name) {
-    var atts, defs, formComponentAttributes, fieldAttributes, fieldAttributesForComponentType, ss;
+    var atts, defs = {}, formComponentAttributes, fieldAttributes, fieldAttributesForComponentType, ss;
 
     atts = _.clone(context || {});
     ss = AutoForm.getFormSchema();
-    defs = Utility.getDefs(ss, atts.name); //defs will not be undefined
+
+    try{
+      // the field might not exist anymore if the schema has changed
+      defs = Utility.getDefs(ss, atts.name);
+    }catch(e){}
 
     // Look up the tree if we're in a helper, checking to see if any ancestor components
     // had a <componentType>-attribute specified.


### PR DESCRIPTION
Hey @aldeed,

I think I've got reactive schemas working with only minor adjustments to your code. It mostly consists of avoiding lookups for fields that no longer exist, and capturing errors thrown by ```Utillity.getDefs```.

What I've found is that some of field template helper's have a reactive dependency on ```Blaze.getData``` from ```Utility.getComponentContext```, and anything that ultimately uses ```AutoForm.getCurrentDataForForm```. When the schema changes, these template helpers re-run, before Blaze actually removes them from the DOM. It seems that we will need checks in place on the helpers (or these utility functions) to check to make sure the field still exists in the schema.

I've tested it in my production app without any issues, but should probably be tested thoroughly.