### PR TITLE
Fix Error with nested schema and update-pushArray #827

### DIFF
--- a/formTypes/update-pushArray.js
+++ b/formTypes/update-pushArray.js
@@ -40,7 +40,7 @@ AutoForm.addFormType('update-pushArray', {
   },
   adjustSchema: function (ss) {
     var scope = this.form.scope, newSchemaDef = {};
-    var searchString = scope+'.$.';
+    var searchString = scope.replace(/[0-9]/g, "$") +'.$.';
 
     // create new SS instance with only the fields that begin with `scope`
     _.each(ss.schema(), function (val, key) {


### PR DESCRIPTION
The commit fix the issue #827: 

When you have defined an 'update-pushArray' scope using dot notation:

```
{{ #autoForm scope="items.0.item" }}
```

The adjustSchema method behaves improperly because is unable to match the searchString defined as:
`searchString = scope.+'.$.';`

With SimpleSchema keys definition with the form of "items.$.item".

```
_.each(ss.schema(), function (val, key) {
      if (key.indexOf(searchString) === 0) {
        newSchemaDef[key.slice(searchString.length)] = val;
      }
    });
```

The fix: Replaces indexes on scope by '$' during the adjustSchema:
`    var searchString = scope.replace(/[0-9]/g, "$") +'.$.';`
 