### PR TITLE
bug fix - drop down 'select' change not being submitted occasionally in each loop

### DIFF
--- a/autoform-events.js
+++ b/autoform-events.js
@@ -404,10 +404,10 @@ Template.autoForm.events({
     }
 
     keyVal = key + '___' + keyVal;
-
-    if (keyVal === lastKeyVal) {
-      return;
-    }
+    //This would cause drop down 'select' change not submit occationally in each loop. Commenting it out fixed the issue.
+    // if (keyVal === lastKeyVal) {
+    //   return;
+    // }
     lastKeyVal = keyVal;
 
     var formId = this.id;


### PR DESCRIPTION
In each loop,  if the old value of a 'select' change equals to the new value of the previous 'select'  change (on another 'select' control), then this select change won't fire submit event.