### PR TITLE
Use the field schema to pass data to a field's context (not as an attribute)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1167,6 +1167,27 @@ summary: {
 
 Tip: Any attribute can instead be provided as a function that returns the attribute's value.
 
+You can pass data structures using the `data` property. They will not be used as attributes, instead they will
+be available in the field's context. For example:
+
+```js
+summary: {
+  type: String,
+  autoform: {
+    afFieldInput: {
+      data: {
+        someArray: ['apple', 'orange', 'banana'],
+        someObj: {
+          complex: {
+            data: 'structure'
+          }
+        }
+      }
+    }
+  }
+}
+```
+
 ## Complex Schemas
 
 You can use mongo dot notation to map an input to a subdocument. For example:

--- a/autoform-inputs.js
+++ b/autoform-inputs.js
@@ -90,7 +90,8 @@ getInputData = function getInputData(defs, hash, value, label, formType) {
           "noselect",
           "options",
           "template",
-          "defaultValue");
+          "defaultValue",
+          "data");
 
   // Add required if required
   if (typeof inputAtts.required === "undefined" && !defs.optional) {
@@ -143,6 +144,14 @@ getInputData = function getInputData(defs, hash, value, label, formType) {
     atts: inputAtts,
     selectOptions: AutoForm.Utility.getSelectOptions(defs, hash)
   };
+
+  /*
+   * Merge data property from the field schema with the context.
+   * We do not want these turned into HTML attributes.
+   */
+  if(hash.data){
+    _.extend(inputTypeContext, hash.data);
+  }
 
   // Before returning the context, we allow the registered form type to
   // adjust it if necessary.


### PR DESCRIPTION
Recreation of #1035 for devel branch.

This PR allows us to pass data through to a field's context via the field's schema definition. Currently, AutoForm turns all of the schema properties into attributes (omitting a handful i.e. options). This is useful when creating schemas on the fly.

I followed your suggestion and updated it to use the component type and extend the context of the field.

Example usage:
```js
summary: {
  type: String,
  autoform: {
    afFieldInput: {
      data: {
        someArray: ['apple', 'orange', 'banana'],
        someObj: {
          complex: {
            data: 'structure'
          }
        }
      }
    }
  }
}
```