### PR TITLE
fix multiple select autosave

### DIFF
--- a/autoform-events.js
+++ b/autoform-events.js
@@ -397,10 +397,11 @@ Template.autoForm.events({
     // loops by continually saying the field changed when it did not,
     // especially in an autosave situation. This is an attempt to
     // prevent that from happening.
-    var keyVal = event.target.value;
+    var $target = $(event.target);
+    var keyVal = $target.val();
     if (event.target.type === 'checkbox') {
       // Special handling for checkboxes, which always have the same value
-      keyVal = keyVal + '_' + $(event.target).prop('checked');
+      keyVal = keyVal + '_' + $target.prop('checked');
     }
 
     keyVal = key + '___' + keyVal;


### PR DESCRIPTION
When we have multiple select then we should detect changes using  $(event.target).val() which is an array of selected values. Not event.target.value which is one of selected values.
Fixed bug: autosave is not triggered when we select second value.