### PR TITLE
fix AutoForm.getFieldValue, add a extra check

### DIFF
--- a/autoform-api.js
+++ b/autoform-api.js
@@ -490,7 +490,7 @@ AutoForm.getInputValue = function autoFormGetInputValue(element, ss) {
 
   // If we have a schema, we can autoconvert to the correct data type
   if (ss && (fieldType = ss.schema(fieldName))) {
-    fieldType = fiedType.type
+    fieldType = fieldType.type
   }
 
   // Get the name of the input type template used to render the input element

--- a/autoform-api.js
+++ b/autoform-api.js
@@ -489,8 +489,8 @@ AutoForm.getInputValue = function autoFormGetInputValue(element, ss) {
   fieldName = field.attr("data-schema-key");
 
   // If we have a schema, we can autoconvert to the correct data type
-  if (ss) {
-    fieldType = ss.schema(fieldName).type;
+  if (ss && (fieldType = ss.schema(fieldName))) {
+    fieldType = fiedType.type
   }
 
   // Get the name of the input type template used to render the input element


### PR DESCRIPTION
Hi @aldeed review this PR.

When I use forms with reactive schema, thanks to this PR https://github.com/aldeed/meteor-autoform/pull/1234, sometimes `AutoForm.getFieldValue` get exceptions on the reactive schema forms.
 `autoform-api.js` AutoForm.getInputValue method, starting on line 492, need a extra check.
from this:
```
  if (ss) {
    fieldType = ss.schema(fieldName).type;
  }
```
to maybe this:
```
if (ss && (fieldType = ss.schema(fieldName))) {
 fieldType = fieldType.type
}
```

Changed `autoform-api.js` is on PR

Thanks for your time and this incredible package.


