### PR TITLE
Force Array Item containing div to 100% width

### DIFF
--- a/templates/bootstrap3/components/afArrayField/afArrayField.html
+++ b/templates/bootstrap3/components/afArrayField/afArrayField.html
@@ -9,7 +9,7 @@
     <ul class="list-group">
       {{#afEachArrayItem name=this.atts.name minCount=this.atts.minCount maxCount=this.atts.maxCount}}
       <li class="list-group-item autoform-array-item">
-        <div>
+        <div style="width: 100%;">
           <div class="autoform-remove-item-wrap">
             {{#if afArrayFieldHasMoreThanMinimum name=../atts.name minCount=../atts.minCount maxCount=../atts.maxCount}}
             <button type="button" class="btn btn-primary autoform-remove-item"><span class="glyphicon glyphicon-minus"></span></button>


### PR DESCRIPTION
In chrome anyways, when you have only one item this div does not always span the full width of the containing panel. So you get this truncated first item but once you add a second item they all then display full width for some reason. Adding this inline style seems to help this template stay true to what I think is the intended format on that first item - 100% width.

Or maybe I am all wrong on this... LOL