### PR TITLE
Remove notice about pre 5.0 restrictions for autosave

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,7 +383,7 @@ Meteor method in this attribute.
 * `resetOnSuccess`: Optional. The form is automatically reset
 for you after a successful submission action. You can skip this by setting this
 attribute to `false`.
-* `autosave`: Optional. Set to `true` to enable automatic form submission for a `type="update"` form. Whenever the `form change` event is emitted, the change will be automatically saved to the database.
+* `autosave`: Optional. Set to `true` to enable automatic form submission. Whenever the `form change` event is emitted, the change will be automatically saved to the database.
 * `autosaveOnKeyup`: Optional. Set to `true` to enable automatic form submission for a `type="update` form on `keyup` event. Whenever a `keyup` event is emitted on a form field, the change will be automatically saved to the database (throttled to 500ms). **It's best to set `trimStrings=false` when using this option. If you don't, spaces may be deleted while typing.**
 * `filter`: Optional. Set to `false` for an insert or update form to skip filtering out unknown properties when cleaning the form document.
 * `autoConvert`: Optional. Set to `false` for an insert or update form to skip autoconverting property values when cleaning the form document.


### PR DESCRIPTION
Removing a notice about autosave working only for type="update". It changed in 5.0 according to this https://github.com/aldeed/meteor-autoform/issues/577

Possibly the docs should be also changed for autosaveOnKeyup.
