### PR TITLE
Fix form reset for "insert" autoforms

### DIFF
--- a/autoform-events.js
+++ b/autoform-events.js
@@ -458,10 +458,8 @@ Template.autoForm.events({
       // there is no need to reset validation for it. No error need be thrown.
     }
 
-    if (this.doc) {
-      event.preventDefault();
-      AutoForm._forceResetFormValues(formId);
-    }
+    event.preventDefault();
+    AutoForm._forceResetFormValues(formId);
 
     // Mark all fields as changed
     updateAllTrackedFieldValues(template);


### PR DESCRIPTION
Use the AutoForm._forceResetFormValues hack even when no doc is set. This fixes default values when reusing the same autoform for multiple inserts, as is the case when using yogiben:autoform-modals (https://github.com/yogiben/meteor-autoform-modals)
