### PR TITLE
Fixes multiple forms with same field name and value only saving first time.

### DIFF
--- a/autoform-events.js
+++ b/autoform-events.js
@@ -2,7 +2,7 @@
 
 // all form events handled here
 var lastAutoSaveElement = null;
-var lastKeyVal = null;
+var lastKeyVals = {};
 
 function beginSubmit(formId, template, hookContext) {
   if (!Utility.checkTemplate(template)) return;
@@ -392,6 +392,8 @@ Template.autoForm.events({
     var key = getKeyForElement(event.target);
     if (!key) {return;}
 
+    var formId = this.id;
+
     // Some plugins, like jquery.inputmask, can cause infinite
     // loops by continually saying the field changed when it did not,
     // especially in an autosave situation. This is an attempt to
@@ -405,12 +407,10 @@ Template.autoForm.events({
 
     keyVal = key + '___' + keyVal;
 
-    if (keyVal === lastKeyVal) {
+    if (formId in lastKeyVals && keyVal === lastKeyVals[formId]) {
       return;
     }
-    lastKeyVal = keyVal;
-
-    var formId = this.id;
+    lastKeyVals[formId] = keyVal;
 
     // Mark field value as changed for reactive updates
     updateTrackedFieldValue(template, key);


### PR DESCRIPTION
This corrects an issue which came into play with the fix for #647.  I
encountered it when using forms in a forEach loop when each form has the
same field names and `autosave=true`.  When updating the same field
with the same value on multiple forms the value was not being submitted.

The same simple logic is being used as before, but now it uses an object
where the last value is looked up by formId (and not just globally).

This closes #1198
