### PR TITLE
Added materialize-tags package to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ Other:
 
 * [comerc:autoform-contenteditable2](https://atmospherejs.com/comerc/autoform-contenteditable2)
 * [hausor:autoform-bs-minicolors](https://atmospherejs.com/hausor/autoform-bs-minicolors)
+* [valedaemon:autoform-materialize-tags](https://atmospherejs.com/valedaemon/autoform-materialize-tags)
 
 #### Themes
 


### PR DESCRIPTION
I've created a new community add-on package, autoform-materialize-tags, and added a link to it under the "Other" category in the README. If I should change the location for the listing, please let me know.

Thank you very much!
