### PR TITLE
Clarify the usage of custom messages for stickyErrors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1393,7 +1393,19 @@ The [Telescope](https://telescope.readme.io/docs) app makes use of this feature.
 Every time AutoForm revalidates your form, it overwrites the list of invalid fields for that form. This means that adding your own errors to the form validation context (using the SimpleSchema API) will not always work because your custom errors will disappear upon first revalidation. To solve this, you can add sticky errors for a form. Sticky errors do not go away unless you reset the form, the form instance is destroyed, or you manually remove them.
 
 - `AutoForm.addStickyValidationError(formId, key, type, [value])`
-- `AutoForm.removeStickyValidationError(formId, key)
+- `AutoForm.removeStickyValidationError(formId, key)`
+
+### Custom Error Messages
+
+Note that when adding a custom sticky validation error message, you need to add the message to your `SimpleSchema` instance. See [this section](https://github.com/aldeed/meteor-simple-schema#customizing-validation-messages) of the SimpleSchema documentation for more information.
+```javascript
+Schema.user.messages({
+  "duplicate email": "You're trying to use an email that already exists."
+})
+
+AutoForm.addStickyValidationError(this.formId, 'email', 'duplicate');
+```
+
 
 ## Defining Custom Input Types
 


### PR DESCRIPTION
This is addressing some confusion as to how to use `addStickyValidationError` with a custom error type and message (see #1338). When attempting to add a sticky error message without first adding a custom error message to your schema instance, you will see "Unknown validation error." This is an attempt to clarify that in the `Readme.`
