### PR TITLE
moved dependencies to NPM package simpl-schema

### DIFF
--- a/.versions
+++ b/.versions
@@ -1,5 +1,4 @@
 aldeed:autoform@5.8.1
-aldeed:simple-schema@1.1.0
 babel-compiler@5.8.24_1
 babel-runtime@0.1.4
 base64@1.0.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ forms with automatic insert and update events, and automatic reactive validation
 
 ## Change Log
 
+### 5.8.2
+
+Moved dependencies from aldeed:simple-schema to npm package simpl-schema 
+
+
 ### 5.8.1
 
 Fix AutoForm.getValidationContext to return correct context when no `formId` argument is provided.

--- a/autoform-api.js
+++ b/autoform-api.js
@@ -2,6 +2,7 @@
 
 // This file defines the public, exported API
 
+
 AutoForm = AutoForm || {}; //exported
 
 /**
@@ -914,12 +915,13 @@ AutoForm._getOptionsForField = function autoFormGetOptionsForField(name) {
  */
 AutoForm.getLabelForField = function autoFormGetLabelForField(name) {
   var ss = AutoForm.getFormSchema(), label = ss.label(name);
+
   // for array items we don't want to inflect the label because
   // we will end up with a number;
-  // TODO this check should probably be in the SimpleSchema code
-  if (SimpleSchema._makeGeneric(name).slice(-1) === "$" && !isNaN(parseInt(label, 10))) {
-    label = null;
-  }
+  // TODO this check must in the SimpleSchema code since we moved to npm package simpl-schema
+  //if (SimpleSchema._makeGeneric(name).slice(-1) === "$" && !isNaN(parseInt(label, 10))) {
+  //  label = null;
+  //}
   return label;
 };
 

--- a/autoform-api.js
+++ b/autoform-api.js
@@ -1,7 +1,7 @@
 /* global AutoForm:true, SimpleSchema, Utility, Hooks, deps, globalDefaultTemplate:true, defaultTypeTemplates:true, validateField, arrayTracker, ReactiveVar, getAllFieldsInForm, setDefaults:true, getFlatDocOfFieldValues, MongoObject */
 
+import SimpleSchema from 'simpl-schema'; //FIXME this is a real dirty fix
 // This file defines the public, exported API
-
 
 AutoForm = AutoForm || {}; //exported
 
@@ -745,6 +745,8 @@ AutoForm.findAttributesWithPrefix = function autoFormFindAttributesWithPrefix(pr
   return result;
 };
 
+
+
 /**
  * @method AutoForm.debug
  * @public
@@ -918,7 +920,7 @@ AutoForm.getLabelForField = function autoFormGetLabelForField(name) {
 
   // for array items we don't want to inflect the label because
   // we will end up with a number;
-  // TODO this check must in the SimpleSchema code since we moved to npm package simpl-schema
+  // TODO this check must move into the SimpleSchema code since we moved to npm package simpl-schema
   //if (SimpleSchema._makeGeneric(name).slice(-1) === "$" && !isNaN(parseInt(label, 10))) {
   //  label = null;
   //}

--- a/autoform-common.js
+++ b/autoform-common.js
@@ -1,6 +1,6 @@
 // This is the only file that is run on the server, too
 
-// Extend the schema options allowed by SimpleSchema
-SimpleSchema.extendOptions({
-  autoform: Match.Optional(Object)
-});
+
+import SimpleSchema from 'simpl-schema';
+
+SimpleSchema.extendOptions(['autoform']);

--- a/autoform-events.js
+++ b/autoform-events.js
@@ -1,5 +1,8 @@
 /* global AutoForm, Hooks, validateField, updateTrackedFieldValue, arrayTracker, updateAllTrackedFieldValues, SimpleSchema */
 
+import SimpleSchema from 'simpl-schema';
+
+
 // all form events handled here
 var lastAutoSaveElement = null;
 var lastKeyVal = null;

--- a/components/autoForm/autoForm.js
+++ b/components/autoForm/autoForm.js
@@ -1,5 +1,7 @@
 /* global AutoForm, ReactiveVar, arrayTracker, Hooks, MongoObject, Utility, setDefaults */
 
+import MongoObject from 'mongo-object';
+
 Template.autoForm.helpers({
   atts: function autoFormTplAtts() {
     // After removing all of the props we know about, everything else should

--- a/package.js
+++ b/package.js
@@ -2,30 +2,36 @@ Package.describe({
   name: "aldeed:autoform",
   summary: "Easily create forms with automatic insert and update, and automatic reactive validation.",
   git: "https://github.com/aldeed/meteor-autoform.git",
-  version: "5.8.1"
+  version: "5.8.2"
 });
+
+Npm.depends({
+  "simpl-schema":"0.1.0",
+});
+
 
 Package.onUse(function(api) {
   // Dependencies
-  api.versionsFrom(['METEOR@0.9.3', 'METEOR@0.9.4', 'METEOR@1.0']);
+  api.versionsFrom(['METEOR@0.9.3', 'METEOR@0.9.4', 'METEOR@1.0', 'METEOR@1.4']);
+
   // common
-  api.use('aldeed:simple-schema@1.1.0');
   api.use('check');
+  api.use('ecmascript');
+
   // client
   api.use(['livedata', 'underscore', 'deps', 'templating', 'ui', 'blaze', 'ejson', 'reactive-var', 'reactive-dict', 'random', 'jquery'], 'client');
   api.use('momentjs:moment@2.10.6', 'client');
   api.use('mrt:moment-timezone@0.2.1', 'client', {weak: true});
   api.use('aldeed:moment-timezone@0.4.0', 'client', {weak: true});
-  api.use(['aldeed:collection2@2.0.0', 'reload'], 'client', {weak: true});
 
-  // Imply SS to make sure SimpleSchema object is available to app
-  api.imply('aldeed:simple-schema');
+  api.use(['aldeed:collection2-core', 'reload'], 'client', {weak: true});
 
   // Exports
   api.export('AutoForm', 'client');
   api.export('Utility', 'client', {testOnly: true});
 
   // Common Files
+  //api.addFiles( '.npm/package/node_modules/simpl-schema/dist/SimpleSchema.js');
   api.addFiles(['autoform-common.js']);
 
   // Client Files
@@ -229,3 +235,6 @@ Package.onTest(function (api) {
   api.use('momentjs:moment', 'client');
   api.addFiles(['tests/utility-tests.js', 'tests/autoform-tests.js']);
 });
+
+
+

--- a/utility.js
+++ b/utility.js
@@ -1,6 +1,9 @@
 /* global Utility:true, MongoObject, AutoForm, moment, SimpleSchema */
 
 import MongoObject from 'mongo-object';
+import SimpleSchema from 'simpl-schema';
+
+
 
 Utility = {
   componentTypeList: ['afArrayField', 'afEachArrayItem', 'afFieldInput', 'afFormGroup', 'afObjectField', 'afQuickField', 'afQuickFields', 'autoForm', 'quickForm'],
@@ -119,9 +122,8 @@ Utility = {
    * Get select options
    */
   getSelectOptions: function getSelectOptions(defs, hash) {
-    var schemaType = defs.type;
+    var schemaType = defs.type.definitions[0].type; //FIXME getDefinitionType independent from arr index
     var selectOptions = hash.options;
-
     // Handle options="allowed"
     if (selectOptions === "allowed") {
       selectOptions = _.map(defs.allowedValues, function(v) {
@@ -129,7 +131,6 @@ Utility = {
         if (hash.capitalize && v.length > 0 && schemaType === String) {
           label = v.charAt(0).toUpperCase() + v.slice(1).toLowerCase();
         }
-
         return {label: label, value: v};
       });
     }
@@ -495,8 +496,6 @@ if (typeof Object.getPrototypeOf !== "function") {
 var isBasicObject = function(obj) {
   return _.isObject(obj) && Object.getPrototypeOf(obj) === Object.prototype;
 };
-
-import SimpleSchema from 'simpl-schema';
 
 /*
  * Extend SS for now; TODO put this in SS package

--- a/utility.js
+++ b/utility.js
@@ -1,5 +1,7 @@
 /* global Utility:true, MongoObject, AutoForm, moment, SimpleSchema */
 
+import MongoObject from 'mongo-object';
+
 Utility = {
   componentTypeList: ['afArrayField', 'afEachArrayItem', 'afFieldInput', 'afFormGroup', 'afObjectField', 'afQuickField', 'afQuickFields', 'autoForm', 'quickForm'],
   /**
@@ -493,6 +495,8 @@ if (typeof Object.getPrototypeOf !== "function") {
 var isBasicObject = function(obj) {
   return _.isObject(obj) && Object.getPrototypeOf(obj) === Object.prototype;
 };
+
+import SimpleSchema from 'simpl-schema';
 
 /*
  * Extend SS for now; TODO put this in SS package

--- a/versions.json
+++ b/versions.json
@@ -1,8 +1,8 @@
 {
   "dependencies": [
     [
-      "aldeed:simple-schema",
-      "1.1.0"
+      "simpl-schema",
+      "0.1.0"
     ],
     [
       "base64",
@@ -46,7 +46,7 @@
     ],
     [
       "jquery",
-      "1.0.1"
+      "1.5.0"
     ],
     [
       "json",


### PR DESCRIPTION
I removed the dependency aldeed:simple-schema and included the npm package "simpl-schema" into the app. The tests run green and it's working in my application. 

It does not create a dependency to aldeed:simple-schema in my meteor app (using this package branch and collection2-core) anymore.

Unfortunately I had to include the ecma package, otherwise it would not have been possible to create use the  "simple-schema" on the server without errors (SimpleSchema.extendOptions would then be undefined).

This may cause issues with apps using lower meteor versions, but this is something I don't have the time to figure out.

There was also an issue with the jquery version but I could not find out, wether this was an issue of my app or the package. It may be moved back to the original version if no issues occur.

Unfortunately the pull request is about to be merged to dev, it would be better in my opinion to have an   own branch von deps_move.

Another issue, I could not 100% fix is, that now the app which uses auto form, needs to call

`SimpleSchema.extendOptions(['autoform']);`

at the very beginning, although it is already declared within the package.
