### PR TITLE
add afFieldValue helper

### DIFF
--- a/autoform-helpers.js
+++ b/autoform-helpers.js
@@ -76,6 +76,15 @@ Template.registerHelper('afFieldValueIs', function autoFormFieldValueIs(options)
 });
 
 /*
+ * afFieldValue
+ */
+Template.registerHelper('afFieldValue', function autoFormFieldValue(options) {
+  options = parseOptions(options, 'afFieldValue');
+
+  return AutoForm.getFieldValue(options.name, options.formId || AutoForm.getFormId());
+});
+
+/*
  * afArrayFieldIsFirstVisible
  */
 Template.registerHelper('afArrayFieldIsFirstVisible', function autoFormArrayFieldIsFirstVisible() {


### PR DESCRIPTION
I found myself wanting to get the current field value within the form. When I found the afFieldValueIs helper I figured it would be possible to just return the value.