### PR TITLE
Add ostrio:autoform-files to the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ Files:
 * [yogiben:autoform-file](https://atmospherejs.com/yogiben/autoform-file)
 * [naxio:autoform-file](https://atmospherejs.com/naxio/autoform-file)
 * [elevatedevdesign:autoform-slingshot](https://github.com/ElevateDev/meteor-autoform-slingshot)
+* [ostrio:autoform-files](https://github.com/VeliovGroup/meteor-autoform-file)
 
 Maps:
 


### PR DESCRIPTION
Some of the packages in the "Files" section are using the deprecated
CollectionFS. ostrio:autoform-files work well and do not use
CollectionFS.