### PR TITLE
WIP / RFC : Add afFieldHelpText to display online text from simpleform schema

### DIFF
--- a/autoform-helpers.js
+++ b/autoform-helpers.js
@@ -12,6 +12,20 @@ function parseOptions(options) {
  */
 
 /*
+ * afFieldHelpText
+ */
+Template.registerHelper('afFieldHelpText', function autoFormFieldHelpText(options) {
+  options = parseOptions(options, 'afFieldHelpText');
+
+  var af = options.ss.get(options.name,'autoform');
+
+  if (af && af.hasOwnProperty('afFieldHelpText')) {
+    return af.afFieldHelpText
+  }
+  return
+});
+
+/*
  * afFieldMessage
  */
 Template.registerHelper('afFieldMessage', function autoFormFieldMessage(options) {

--- a/autoform-helpers.js
+++ b/autoform-helpers.js
@@ -20,7 +20,11 @@ Template.registerHelper('afFieldHelpText', function autoFormFieldHelpText(option
   var af = options.ss.get(options.name,'autoform');
 
   if (af && af.hasOwnProperty('afFieldHelpText')) {
-    return af.afFieldHelpText
+    if (_.isFunction(af.afFieldHelpText)) {
+      return af.afFieldHelpText()
+    } else {
+      return af.afFieldHelpText
+    }
   }
   return
 });

--- a/templates/bootstrap3/components/afArrayField/afArrayField.html
+++ b/templates/bootstrap3/components/afArrayField/afArrayField.html
@@ -1,6 +1,7 @@
 <template name="afArrayField_bootstrap3">
   <div class="panel {{panelClass}}">
     <div class="panel-heading {{headingClass}}">{{afFieldLabelText name=this.atts.name}}</div>
+    <div class="help-text">{{{afFieldHelpText name=this.atts.name}}}</div>
     {{#if afFieldIsInvalid name=this.atts.name}}
     <div class="panel-body has-error">
       <span class="help-block">{{{afFieldMessage name=this.atts.name}}}</span>

--- a/templates/bootstrap3/components/afArrayField/afArrayField.html
+++ b/templates/bootstrap3/components/afArrayField/afArrayField.html
@@ -1,7 +1,7 @@
 <template name="afArrayField_bootstrap3">
   <div class="panel {{panelClass}}">
     <div class="panel-heading {{headingClass}}">{{afFieldLabelText name=this.atts.name}}</div>
-    <div class="help-text">{{{afFieldHelpText name=this.atts.name}}}</div>
+    <p class="form-text text-muted">{{{afFieldHelpText name=this.atts.name}}}</p>
     {{#if afFieldIsInvalid name=this.atts.name}}
     <div class="panel-body has-error">
       <span class="help-block">{{{afFieldMessage name=this.atts.name}}}</span>

--- a/templates/bootstrap3/components/afFormGroup/afFormGroup.html
+++ b/templates/bootstrap3/components/afFormGroup/afFormGroup.html
@@ -4,6 +4,7 @@
     <label {{bsFieldLabelAtts}}>{{#if this.labelText}}{{this.labelText}}{{else}}{{afFieldLabelText name=this.name}}{{/if}}</label>
     {{/unless}}
     {{> afFieldInput this.afFieldInputAtts}}
+    <div class="help-text">{{{afFieldHelpText name=this.name}}}</div>
     <span class="help-block">{{{afFieldMessage name=this.name}}}</span>
   </div>
 </template>

--- a/templates/bootstrap3/components/afFormGroup/afFormGroup.html
+++ b/templates/bootstrap3/components/afFormGroup/afFormGroup.html
@@ -4,7 +4,7 @@
     <label {{bsFieldLabelAtts}}>{{#if this.labelText}}{{this.labelText}}{{else}}{{afFieldLabelText name=this.name}}{{/if}}</label>
     {{/unless}}
     {{> afFieldInput this.afFieldInputAtts}}
-    <div class="help-text">{{{afFieldHelpText name=this.name}}}</div>
+    <p class="form-text text-muted">{{{afFieldHelpText name=this.name}}}</p>
     <span class="help-block">{{{afFieldMessage name=this.name}}}</span>
   </div>
 </template>

--- a/templates/bootstrap3/components/afObjectField/afObjectField.html
+++ b/templates/bootstrap3/components/afObjectField/afObjectField.html
@@ -6,6 +6,7 @@
     </div>
     {{/with}}
     <div class="panel-body {{bodyClass}}">
+      <div class="help-text">{{{afFieldHelpText name=this.name}}}</div>
       {{#if afFieldIsInvalid name=this.name}}
       <span class="help-block">{{{afFieldMessage name=this.name}}}</span>
       {{/if}}

--- a/templates/bootstrap3/components/afObjectField/afObjectField.html
+++ b/templates/bootstrap3/components/afObjectField/afObjectField.html
@@ -6,7 +6,7 @@
     </div>
     {{/with}}
     <div class="panel-body {{bodyClass}}">
-      <div class="help-text">{{{afFieldHelpText name=this.name}}}</div>
+      <p class="form-text text-muted">{{{afFieldHelpText name=this.name}}}</p>
       {{#if afFieldIsInvalid name=this.name}}
       <span class="help-block">{{{afFieldMessage name=this.name}}}</span>
       {{/if}}

--- a/templates/plain/components/afArrayField/afArrayField.html
+++ b/templates/plain/components/afArrayField/afArrayField.html
@@ -1,6 +1,7 @@
 <template name="afArrayField_plain">
   <fieldset>
     <legend>{{afFieldLabelText name=this.atts.name}}</legend>
+    <div class="help-text" >{{{afFieldHelpText name=this.atts.name}}}</div>
     {{#if afFieldIsInvalid name=this.atts.name}}
     <div class="autoform-array-field-error">
       {{{afFieldMessage name=this.atts.name}}}


### PR DESCRIPTION
This is a simple patch that adds help text support to autoform. I tried to be as least invasive as possible. 
To use this new feature, you just need to add the `instruction` field to your simpleform definition with the text you want to display. To customize the div, you can use the `help-text` class. 

This is WIP as it should be autoform specific and maybe adding a new field like `afFieldHelpText` instead of `instructions` in the autoform object would be more appropriate.
