### PR TITLE
Add new quickform option 'hiddenFields' to selectively hide form fields

### DIFF
--- a/components/afQuickField/afQuickField.js
+++ b/components/afQuickField/afQuickField.js
@@ -1,5 +1,16 @@
 /* global AutoForm */
 
+Template.afQuickField.onCreated(function onCreated() {
+  const name = this.data.name
+  if (this.data.hiddenFields && _.some(Utility.stringToArray(this.data.hiddenFields),
+    function(field) {
+      return (name == field) } )) {
+        this.data.isHidden = true
+        // both class for bs3 and bs4
+        this.data['formgroup-class'] = "d-none hidden"
+    }
+})
+
 Template.afQuickField.helpers({
   isGroup: function afQuickFieldIsGroup() {
     var c = AutoForm.Utility.getComponentContext(this, "afQuickField");

--- a/templates/bootstrap3/components/quickForm/quickForm.js
+++ b/templates/bootstrap3/components/quickForm/quickForm.js
@@ -18,7 +18,7 @@ Template.quickForm_bootstrap3.helpers({
   quickFieldsAtts: function () {
     // These are the quickForm attributes that we want to forward to
     // the afQuickFields component.
-    return _.pick(this.atts, 'fields', 'id-prefix', 'input-col-class', 'label-class');
+    return _.pick(this.atts, 'fields', 'hiddenFields', 'id-prefix', 'input-col-class', 'label-class');
   },
   submitButtonAtts: function bsQuickFormSubmitButtonAtts() {
     var qfAtts = this.atts;


### PR DESCRIPTION

Few lines of codes to add a new option to quickform to selectively hide form fields. It is similar to `omitFields`, but we only change the type of the fields to 'hidden' instead of removing it completely.
Useful when it is necessary to present only part of the form .