### PR TITLE
fix afArrayField panelClass

### DIFF
--- a/templates/bootstrap3/components/afArrayField/afArrayField.js
+++ b/templates/bootstrap3/components/afArrayField/afArrayField.js
@@ -1,6 +1,6 @@
 Template.afArrayField_bootstrap3.helpers({
   panelClass: function () {
-    return this.panelClass || 'panel-default';
+    return this.atts.panelClass || 'panel-default';
   },
   headingClass: function () {
     return this.atts.headingClass || '';


### PR DESCRIPTION
Regarding this issue https://github.com/aldeed/meteor-autoform/issues/1412
in https://github.com/aldeed/meteor-autoform/blob/devel/templates/bootstrap3/components/afArrayField/afArrayField.js
`return this.panelClass || 'panel-default';`
should be 
`return this.atts.panelClass || 'panel-default';`
like in heading class.