### PR TITLE
Update link for autoform slider extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ Maps:
 
 Ranges/Sliders:
 
-* [elevatedevdesign:autoform-nouislider](https://github.com/ElevateDev/meteor-autoform-nouislider)
+* [muqube:autoform-nouislider](https://github.com/muqube/meteor-autoform-nouislider)
 
 Payments
 


### PR DESCRIPTION
elevatedevdesign:autoform-nouislider is no longer maintained. They also reference in their repo to [muqube:autoform-nouislider](https://github.com/muqube/meteor-autoform-nouislider) which is actively maintained and compatible with the latest autoform 6.0.0 (beginning with their package version 0.4.1)