### PR TITLE
Add mongo-object

### DIFF
--- a/package.js
+++ b/package.js
@@ -7,6 +7,10 @@ Package.describe({
   version: '7.0.1'
 })
 
+Npm.depends({
+  'mongo-object': '3.0.1'
+});
+
 Package.onUse(function (api) {
   api.versionsFrom('METEOR@1.3')
 


### PR DESCRIPTION
Autoform relies on mongo-object internally but doesn't state it as an explicit NPM dependency because it's one of the sub dependencies of simple-schema which you get it by default when you install simpl-schema. The problem comes apparent only when you remove the simpl-schema NPM package. 