### PR TITLE
change event resolves the parent form correctly now

### DIFF
--- a/autoform-events.js
+++ b/autoform-events.js
@@ -449,7 +449,7 @@ Template.autoForm.events({
       return
     }
 
-    const parentForm = event.target.form && event.target.closest('form')
+    const parentForm = event.target.form ?? event.target.closest('form')
     const formId = parentForm.getAttribute('id')
     const expectedId = this.id
 

--- a/autoform-events.js
+++ b/autoform-events.js
@@ -449,8 +449,11 @@ Template.autoForm.events({
       return
     }
 
-    const formId = event.target.closest('form').id
-    if (formId !== this.id) return
+    const parentForm = event.target.form && event.target.closest('form')
+    const formId = parentForm.getAttribute('id')
+    const expectedId = this.id
+
+    if (formId !== expectedId) return
 
     // Some plugins, like jquery.inputmask, can cause infinite
     // loops by continually saying the field changed when it did not,


### PR DESCRIPTION
When having multiple forms on one page then changing a select input will not find the correct parent form but the next `input` field (if any is placed before the `select`)

This broke reactivity, which as required for example, when using simple schema and computed fields that rely on `AutoForm.getFieldValue`.

This is now fixed